### PR TITLE
VCST-4477: Selected statuses are lost after adding a new product in Order Edit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,4 +9,7 @@
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+  </ItemGroup>  
 </Project>

--- a/README.md
+++ b/README.md
@@ -2,26 +2,52 @@
 
 [![CI status](https://github.com/VirtoCommerce/vc-module-order-management/workflows/Module%20CI/badge.svg?branch=dev)](https://github.com/VirtoCommerce/vc-module-order-management/actions?query=workflow%3A"Module+CI") [![Quality gate](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-order-management&metric=alert_status&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-order-management) [![Reliability rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-order-management&metric=reliability_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-order-management) [![Security rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-order-management&metric=security_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-order-management) [![Sqale rating](https://sonarcloud.io/api/project_badges/measure?project=VirtoCommerce_vc-module-order-management&metric=sqale_rating&branch=dev)](https://sonarcloud.io/dashboard?id=VirtoCommerce_vc-module-order-management)
 
-The “Order Management” module in Virto Commerce is an attempt to split the old [“Order”](https://github.com/VirtoCommerce/vc-module-order) module into two modules where the new module will take over the whole functionality of managing the composition of order products, their prices, quantities, adding new and deleting old items, etc.
+## Overview
+
+The Order Management module consolidates order composition business rules that previously lived inside the monolithic [Order module](https://github.com/VirtoCommerce/vc-module-order). It extends the Back Office Order Edit experience with an **Add Product** workflow that evaluates prices through the catalog search pipeline and persists new line items without losing any unsaved edits the user has made on existing items (line-item statuses, quantity, price, discounts, order-level fields).
+
+The module layers on top of the core Orders module — it does not replace it. Orders continue to be stored and served by `VirtoCommerce.Orders`; this module adds a dedicated REST controller and a GraphQL schema scope (`order-management`) for composition operations.
 
 ## Key features
 
-Virto Commerce Order Management module supports the following functionalities:
+- **Add products to an existing order.** `PUT api/order-management/add-items/{orderId}` appends new line items, evaluates prices via `VirtoCommerce.XCatalog` when available, and persists the order in a single round trip.
+- **Preserves unsaved UI edits.** After Add Product, previously-selected line-item statuses, edited quantities and prices, and any order-level edits are kept. The client reconciles the fresh server entity with the local state by diffing against the baseline so the user's in-flight work is not wiped.
+- **Correct optimistic concurrency after Add Product.** The client adopts the server-refreshed `rowVersion`/`modifiedDate` as part of the reconcile, so the next Save does not raise "The order has been modified by another user" (409).
+- **Clear validation of store references.** Add-items requests fail fast with an `InvalidOperationException` naming the missing store id when the order references a store that no longer exists, instead of bubbling a cryptic `NullReferenceException` from the catalog search pipeline.
+- **Resilient price evaluation.** Price lookup via `SearchProductQuery` is best-effort — if the pipeline is unavailable or fails for any reason, the new line item is still created (with Price = 0) and logged, rather than the whole request erroring out.
+- **Back Office toolbar buttons.** Registers **Add Product** and **Remove** toolbar actions on the Order Line Items blade.
+- **GraphQL schema scope `order-management`.** A scoped schema is exposed at the platform GraphQL endpoint for experience-API consumers.
 
-* Changing Order products (quantity, product change, new products).
-* Possibility to change Product items.
+## Settings
+
+This module does not expose any runtime settings of its own (`ModuleConstants.Settings.AllSettings` is empty). Line-item statuses, customer statuses and other order-level dictionaries continue to be configured through the core Orders module (for example the `OrderLineItem.Statuses` dictionary used by the line-items grid).
+
+### Permissions
+
+The module registers the following permissions (group: **OrderManagement**):
+
+| Key                         | Purpose                                     |
+| --------------------------- | ------------------------------------------- |
+| `order-management:access`   | Access the Order Management UI              |
+| `order-management:read`     | Read order composition                      |
+| `order-management:create`   | Create new orders via this module           |
+| `order-management:update`   | Update orders (required for **Add Product**)|
+| `order-management:delete`   | Delete orders via this module               |
+
+In addition, **Add Product** applies the core Orders `OrderAuthorizationRequirement` with the `Update` permission, so the caller must also satisfy the standard order-level authorization (scopes, store access, etc.) configured in the Orders module.
 
 ## Documentation
 
-* [View on GitHub](https://github.com/VirtoCommerce/vc-module-order/)
+- [Module on GitHub](https://github.com/VirtoCommerce/vc-module-order-management)
+- [Orders module](https://github.com/VirtoCommerce/vc-module-order)
 
 ## References
 
-* [Deployment](https://docs.virtocommerce.org/platform/developer-guide/Tutorials-and-How-tos/Tutorials/deploy-module-from-source-code/)
-* [Installation](https://docs.virtocommerce.org/platform/user-guide/modules-installation/)
-* [Home](https://virtocommerce.com)
-* [Community](https://www.virtocommerce.org)
-* [Download latest release](https://github.com/VirtoCommerce/vc-module-order-management/releases/latest)
+- [Deployment](https://docs.virtocommerce.org/platform/developer-guide/Tutorials-and-How-tos/Tutorials/deploy-module-from-source-code/)
+- [Installation](https://docs.virtocommerce.org/platform/user-guide/modules-installation/)
+- [Home](https://virtocommerce.com)
+- [Community](https://www.virtocommerce.org)
+- [Download latest release](https://github.com/VirtoCommerce/vc-module-order-management/releases/latest)
 
 ## License
 

--- a/src/VirtoCommerce.OrderManagement.Web/Controllers/Api/OrderManagementController.cs
+++ b/src/VirtoCommerce.OrderManagement.Web/Controllers/Api/OrderManagementController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -5,12 +6,15 @@ using System.Threading.Tasks;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.OrdersModule.Core.Model;
 using VirtoCommerce.OrdersModule.Core.Services;
 using VirtoCommerce.OrdersModule.Data.Authorization;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.StoreModule.Core.Services;
 using VirtoCommerce.XCatalog.Core.Queries;
+using VirtoCommerce.XCatalog.Core.Models;
 using Permissions = VirtoCommerce.OrderManagement.Core.ModuleConstants.Security.Permissions;
 
 namespace VirtoCommerce.OrderManagement.Web.Controllers.Api
@@ -20,12 +24,16 @@ namespace VirtoCommerce.OrderManagement.Web.Controllers.Api
         IMediator mediator,
         IItemService itemsService,
         IAuthorizationService authorizationService,
-        ICustomerOrderService customerOrderService) : Controller
+        ICustomerOrderService customerOrderService,
+        IStoreService storeService,
+        ILogger<OrderManagementController> logger) : Controller
     {
         private readonly IMediator _mediator = mediator;
         private readonly IItemService _itemsService = itemsService;
         private readonly IAuthorizationService _authorizationService = authorizationService;
         private readonly ICustomerOrderService _customerOrderService = customerOrderService;
+        private readonly IStoreService _storeService = storeService;
+        private readonly ILogger<OrderManagementController> _logger = logger;
 
         [HttpPut]
         [Route("add-items/{orderId}")]
@@ -48,21 +56,24 @@ namespace VirtoCommerce.OrderManagement.Web.Controllers.Api
                 return Forbid();
             }
 
+            if (string.IsNullOrEmpty(order.StoreId))
+            {
+                throw new InvalidOperationException($"Order '{orderId}' has no StoreId set.");
+            }
+
+            var store = await _storeService.GetByIdAsync(order.StoreId);
+            if (store == null)
+            {
+                throw new InvalidOperationException($"Store '{order.StoreId}' referenced by order '{orderId}' does not exist.");
+            }
+
             var products = await _itemsService.GetNoCloneAsync(productIds);
             if (products.IsNullOrEmpty())
             {
                 return NotFound();
             }
 
-            var searchProductQuery = AbstractTypeFactory<SearchProductQuery>.TryCreateInstance();
-            searchProductQuery.StoreId = order.StoreId;
-            searchProductQuery.CultureName = order.LanguageCode;
-            searchProductQuery.CurrencyCode = order.Currency;
-            searchProductQuery.Filter = "availability:InStock";
-            searchProductQuery.ObjectIds = products.Select(x => x.Id).ToArray();
-            searchProductQuery.IncludeFields = ["items.id", "items.price.discountAmount.amount", "items.price.list.amount", "items.price.currency"];
-
-            var searchProductResponse = await _mediator.Send(searchProductQuery, cancellationToken);
+            var productPrices = await TryGetProductPricesAsync(order, products, cancellationToken);
 
             foreach (var product in products)
             {
@@ -78,10 +89,10 @@ namespace VirtoCommerce.OrderManagement.Web.Controllers.Api
                 lineItem.Price = 0;
                 lineItem.DiscountAmount = 0;
 
-                var productPrice = searchProductResponse.Results.FirstOrDefault(x => x.Id == product.Id);
+                var productPrice = productPrices?.FirstOrDefault(x => x.Id == product.Id);
                 if (productPrice != null)
                 {
-                    var price = productPrice.AllPrices.FirstOrDefault(x => x.Currency.Code == order.Currency);
+                    var price = productPrice.AllPrices?.FirstOrDefault(x => x.Currency?.Code == order.Currency);
                     lineItem.Price = price?.ListPrice?.Amount ?? 0;
                     lineItem.DiscountAmount = price?.DiscountAmount?.Amount ?? 0;
                 }
@@ -92,6 +103,36 @@ namespace VirtoCommerce.OrderManagement.Web.Controllers.Api
             await _customerOrderService.SaveChangesAsync([order]);
 
             return Ok(order);
+        }
+
+        private async Task<IList<ExpProduct>> TryGetProductPricesAsync(CustomerOrder order, IList<CatalogModule.Core.Model.CatalogProduct> products, CancellationToken cancellationToken)
+        {
+            // Price lookup is a best-effort: if it fails (e.g. store/currency misconfiguration, missing xcatalog pipeline deps),
+            // we still let the user add the product with Price = 0 and set it manually.
+            if (string.IsNullOrEmpty(order.StoreId) || string.IsNullOrEmpty(order.Currency))
+            {
+                return null;
+            }
+
+            try
+            {
+                var searchProductQuery = AbstractTypeFactory<SearchProductQuery>.TryCreateInstance();
+                searchProductQuery.StoreId = order.StoreId;
+                searchProductQuery.CultureName = order.LanguageCode;
+                searchProductQuery.CurrencyCode = order.Currency;
+                searchProductQuery.Filter = "availability:InStock";
+                searchProductQuery.ObjectIds = products.Select(x => x.Id).ToArray();
+                searchProductQuery.Take = products.Count;
+                searchProductQuery.IncludeFields = ["items.id", "items.price.discountAmount.amount", "items.price.list.amount", "items.price.currency"];
+
+                var searchProductResponse = await _mediator.Send(searchProductQuery, cancellationToken);
+                return searchProductResponse?.Results;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to evaluate prices for products added to order {OrderId}. Line items will be created with Price = 0.", order.Id);
+                return null;
+            }
         }
     }
 }

--- a/src/VirtoCommerce.OrderManagement.Web/Scripts/services/order-management-service.js
+++ b/src/VirtoCommerce.OrderManagement.Web/Scripts/services/order-management-service.js
@@ -56,9 +56,68 @@ angular.module('virtoCommerce.orderManagement')
                 var productIds = _.map(products, 'id');
 
                 orderManagementApi.addItems({ orderId: blade.currentEntity.id }, productIds, function (result) {
-                    blade.refresh(result);
-                    if (angular.isFunction(blade.parentRefresh)) {
-                        blade.parentRefresh(result);
+                    if (result) {
+                        var parentBlade = blade.parentBlade;
+                        var baseline = parentBlade && parentBlade.origEntity;
+
+                        // Adopt the fresh server entity (new items, recalculated totals, bumped rowVersion)
+                        // while preserving the user's unsaved edits on existing items and order-level fields.
+                        mergeServerStateInPlace(blade.currentEntity, result, baseline);
+
+                        // Advance the origEntity baseline to the post-save server state so subsequent
+                        // dirty-checks and Cancel use the updated server state as the reference point.
+                        if (baseline) {
+                            mergeServerStateInPlace(baseline, result, null);
+                        }
+                    }
+                    blade.refresh();
+                });
+            }
+
+            // Merges `source` into `target` in place (references are preserved). When `baseline`
+            // is provided, any field where `target` already differs from `baseline` is treated as
+            // a user edit and left untouched; all other fields are overwritten from `source`.
+            // Works at both the root level and per line item (matched by id). New items in
+            // `source` that are not yet in `target` are appended.
+            function mergeServerStateInPlace(target, source, baseline) {
+                if (!target || !source) {
+                    return;
+                }
+
+                var fresh = angular.copy(source);
+
+                _.each(fresh, function (value, key) {
+                    if (key === 'items') {
+                        return;
+                    }
+                    if (typeof value === 'function' || key.charAt(0) === '$') {
+                        return;
+                    }
+                    if (baseline && !angular.equals(baseline[key], target[key])) {
+                        return;
+                    }
+                    target[key] = value;
+                });
+
+                target.items = target.items || [];
+                var targetItemsById = _.indexBy(target.items, 'id');
+                var baselineItemsById = baseline ? _.indexBy(baseline.items || [], 'id') : {};
+
+                _.each(fresh.items || [], function (srcItem) {
+                    var curItem = targetItemsById[srcItem.id];
+                    if (curItem) {
+                        var baseItem = baselineItemsById[srcItem.id];
+                        _.each(srcItem, function (value, key) {
+                            if (typeof value === 'function' || key.charAt(0) === '$') {
+                                return;
+                            }
+                            if (baseItem && !angular.equals(baseItem[key], curItem[key])) {
+                                return;
+                            }
+                            curItem[key] = value;
+                        });
+                    } else {
+                        target.items.push(srcItem);
                     }
                 });
             }

--- a/src/VirtoCommerce.OrderManagement.Web/VirtoCommerce.OrderManagement.Web.csproj
+++ b/src/VirtoCommerce.OrderManagement.Web/VirtoCommerce.OrderManagement.Web.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="VirtoCommerce.CatalogModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.OrdersModule.Data" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.StoreModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VirtoCommerce.OrderManagement.Web/module.manifest
+++ b/src/VirtoCommerce.OrderManagement.Web/module.manifest
@@ -8,6 +8,7 @@
   <dependencies>
     <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />
     <dependency id="VirtoCommerce.Orders" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Store" version="3.1000.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" optional="true" />
   </dependencies>
 

--- a/src/VirtoCommerce.OrderManagement.Web/module.manifest
+++ b/src/VirtoCommerce.OrderManagement.Web/module.manifest
@@ -11,8 +11,8 @@
     <dependency id="VirtoCommerce.XCatalog" version="3.1000.0" optional="true" />
   </dependencies>
 
-  <title>New Order Management</title>
-  <description>Functionality for editing the composition of orders.</description>
+  <title>Order Management (Business Rules)</title>
+  <description>Consolidates order management business rules.</description>
 
   <authors>
     <author>Evgenii Kolosov</author>
@@ -29,7 +29,7 @@
   <moduleType>VirtoCommerce.OrderManagement.Web.Module, VirtoCommerce.OrderManagement.Web</moduleType>
 
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2025 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2026 Virto Commerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/src/VirtoCommerce.OrderManagement.Web/package-lock.json
+++ b/src/VirtoCommerce.OrderManagement.Web/package-lock.json
@@ -476,9 +476,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1736,16 +1736,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -1827,27 +1817,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -1879,16 +1848,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shallow-clone": {
@@ -2014,16 +1973,15 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.16",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
-      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.4.0.tgz",
+      "integrity": "sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
         "terser": "^5.31.1"
       },
       "engines": {


### PR DESCRIPTION
## Description
fix: Selected statuses are lost after adding a new product in Order Edit

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4477
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.OrderManagement_3.1001.0-pr-7-8890.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client-side order state reconciliation after `add-items` and modifies server-side add-items behavior (store validation and best-effort price lookup), which could affect order edit workflows and pricing in edge cases.
> 
> **Overview**
> Fixes Order Edit’s **Add Product** flow so adding line items no longer overwrites in-flight user edits (e.g., selected statuses, quantities/prices/discounts, and order-level fields) by reconciling the refreshed server order into the existing client entity and updating the baseline used for dirty-checking.
> 
> Hardens `PUT api/order-management/add-items/{orderId}` by validating `StoreId`/store existence up front and making XCatalog price evaluation best-effort (logs and falls back to `Price = 0` on failure). Also updates module deps/metadata (adds Store module dependency and suppresses a NuGet audit advisory).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889000896886b5267e5fcbbcfeca0d6a30226165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->